### PR TITLE
feat: Adjust leadership images, update text, and enlarge event photos

### DIFF
--- a/components/EventsSection.tsx
+++ b/components/EventsSection.tsx
@@ -180,7 +180,7 @@ function PastEventCard({ event }: { event: Event }) {
             </h5>
             <div className="flex overflow-x-auto space-x-4 pb-4" style={{ scrollSnapType: 'x mandatory' }}>
               {event.gallery.map((photo, index) => (
-                <div key={index} className="flex-shrink-0 w-2/3 md:w-1/3 rounded-lg overflow-hidden" style={{ scrollSnapAlign: 'start' }}>
+                <div key={index} className="flex-shrink-0 w-full md:w-1/2 rounded-lg overflow-hidden" style={{ scrollSnapAlign: 'start' }}>
                   {typeof photo === 'string' ? (
                     <img
                       src={photo}

--- a/components/StudentLeadershipSection.tsx
+++ b/components/StudentLeadershipSection.tsx
@@ -9,7 +9,7 @@ const leadershipTeam = [
   {
     name: 'Ryan Smith',
     image: '/img/IMG_0292.jpeg',
-    description: 'Hi I’m Ryan, I’m the xo, and I make sure everyone’s job is done correctly and efficiently. I also work with the CO and CMC on big projects and ideas for the unit.',
+    description: 'Hi I’m Ryan, I’m the Executive Officer (XO), and I make sure everyone’s job is done correctly and efficiently. I also work with the CO and CMC on big projects and ideas for the unit.',
   },
   {
     name: 'Xander Powell',
@@ -86,6 +86,7 @@ export default function StudentLeadershipSection() {
                   alt={leader.name}
                   layout="fill"
                   objectFit="cover"
+                  objectPosition="center 20%"
                   className="rounded-t-lg"
                 />
               </div>


### PR DESCRIPTION
This commit addresses three visual and content requests:

1.  The student leadership images are adjusted to be positioned lower, ensuring faces are fully visible. This is achieved by adding `objectPosition="center 20%"` to the `Image` component.
2.  Ryan Smith's title in his description has been updated from "xo" to "Executive Officer (XO)" for clarity and professionalism.
3.  The event photos in the gallery are now larger, improving visibility. The width classes were changed from `w-2/3 md:w-1/3` to `w-full md:w-1/2`.